### PR TITLE
Fixes stopAll() object is destroyed beforehand, causing an error here

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,11 +74,12 @@ exports.register = (ipcMain, registeredPaths, { debug = false }) => {
   });
 };
 
-// FIXME: object is destroyed beforehand, causing an error here
 exports.stopAll = () => {
   Object.keys(workers).map(processName => {
-    workers[processName].windowObject.webContents.send('WORKER_KILL');
-    workers[processName].windowObject.close();
+    if (!workers[processName].windowObject.isDestroyed()) {
+      workers[processName].windowObject.webContents.send('WORKER_KILL');
+      workers[processName].windowObject.close();
+    }
     delete workers[processName];
   });
 };


### PR DESCRIPTION
I added the isDestroyed function to the stopAll function and it resolves the following error:

A user quitting an app from the dock on macOS would previously result in a "A JavaScript error occurred in the main process" message with the stacktrace showing electron-load-balancer. The error is now fixed because the window close function will never execute when the window is already destroyed.